### PR TITLE
Update list-all command

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -8,7 +8,7 @@ if [ -n "$OAUTH_TOKEN" ]; then
 fi
 cmd="$cmd $releases_path"
 
-cmd="$cmd | tr '<>' ',,' | awk -F, '/tar.gz/{ print \$13 }' | sed -e 's/.tar.gz//g' -e 's/redis-//' -e 's/stable//'"
+cmd="$cmd | awk 'match(\$0, /redis-[0-9.]*.tar.gz/) { print substr(\$0, RSTART, RLENGTH) }' | sed -e 's/\.tar\.gz//' -e 's/redis-//'"
 
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {


### PR DESCRIPTION
This pull request intend to address the problem with listing redis versions not working properly on macOS. I've tested this change locally and it seems to be working correctly. Feel free to test this on Gnu/Linux as well.

Closes #5 