### PR TITLE
Fix "curl: (33) HTTP server doesn't seem to support byte ranges. Cannot resume."

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -50,7 +50,7 @@ download_source() {
   local download_path=$3
   local download_url=$(get_download_url $install_type $version)
 
-  curl -Lo $download_path -C - $download_url
+  curl -Lo $download_path $download_url
 }
 
 


### PR DESCRIPTION
This is the cleaned up PR. Actually there is just one line of changes. Not sure if you encountered this, but for me, when I tried to use this plugin to install `redis`, it failed with the error above.