### PR TITLE
Change Redis URLs to HTTPS

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -67,7 +67,7 @@ get_download_file_path() {
 get_download_url() {
   local install_type=$1
   local version=$2
-  echo "http://download.redis.io/releases/redis-${version}.tar.gz"
+  echo "https://download.redis.io/releases/redis-${version}.tar.gz"
 }
 
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-releases_path=http://download.redis.io/releases/
+releases_path=https://download.redis.io/releases/
 
 cmd="curl -s"
 if [ -n "$OAUTH_TOKEN" ]; then


### PR DESCRIPTION
This change modifies the paths that point to download.redis.io from http to https. (The upstream service seems to serve http directly, without a redirect to https).