### PR TITLE
Fix issues building with Lua and MacPorts

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -5,6 +5,8 @@ install_redis() {
   local version=$2
   local install_path=$3
 
+  local openssl_prefix
+
   if [ "$TMPDIR" = "" ]; then
     local tmp_download_dir=$(mktemp -d)
   else
@@ -21,18 +23,31 @@ install_redis() {
     tar zxf $source_path || exit 1
     cd $(untar_path $install_type $version $tmp_download_dir)
 
+    # Make a minor fix that solves problems when newer versions of Lua are
+    # installed on the system
+    patch -Np1 -i "${ASDF_PLUGIN_PATH:-$HOME/.asdf/plugins/redis}/lib/adjust-include-paths.patch" || exit 1
+
     if [[ -n "${REDIS_APPLY_PATCHES:-}" ]]; then
       apply_patches "$(fetch_patches "$REDIS_APPLY_PATCHES")"
     fi
 
+    REDIS_CONFIGURE_OPTIONS=
+
+    openssl_prefix=$(get_openssl_prefix)
+    if [[ -z $openssl_prefix ]]; then
+      echo "WARNING: OpenSSL is not available!" >&2
+    else
+      REDIS_CONFIGURE_OPTIONS="BUILD_TLS=yes OPENSSL_PREFIX=\"$openssl_prefix\" "
+    fi
+
+    REDIS_CONFIGURE_OPTIONS+=$REDIS_EXTRA_CONFIGURE_OPTIONS
+
     # set in os_based_configure_options
     # we unset it here because echo-ing changes the return value of the function
     unset ASDF_PKG_MISSING
-
-    make PREFIX=$ASDF_INSTALL_PATH install || exit 1
+    make PREFIX="$install_path" $REDIS_CONFIGURE_OPTIONS install || exit 1
   )
 }
-
 
 untar_path() {
   local install_type=$1
@@ -124,4 +139,31 @@ apply_patches() {
   done
 }
 
-install_redis $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
+get_openssl_prefix() {
+  local openssl_prefix
+
+  # Linux and also MacPorts
+  openssl_prefix=$(pkg-config --variable=prefix libcrypto 2>/dev/null);
+
+  # Use OpenSSL from Homebrew
+  if [[ -z $openssl_prefix ]]; then
+    # Attempt to find HOMEBREW_PREFIX if the var is not set
+    if [[ -z $HOMEBREW_PREFIX ]]; then
+      HOMEBREW_PREFIX=$(brew --prefix 2>/dev/null)
+    fi
+
+    if [[ -z $openssl_prefix && -d "$HOMEBREW_PREFIX/opt" ]]; then
+      if [[ -d "$HOMEBREW_PREFIX/opt/openssl@3" ]]; then
+        export HOMEBREW_PREFIX
+        openssl_prefix="$HOMEBREW_PREFIX/opt/openssl@3"
+      elif [[ -d "$HOMEBREW_PREFIX/opt/openssl" ]]; then
+        export HOMEBREW_PREFIX
+        openssl_prefix="$HOMEBREW_PREFIX/opt/openssl"
+      fi
+    fi
+  fi
+
+  echo "$openssl_prefix"
+}
+
+install_redis "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+: ${ASDF_DATA_DIR:=${HOME}/.asdf}
+: ${ASDF_PLUGIN_PATH:=${ASDF_DATA_DIR}/plugins/redis}
+
 install_redis() {
   local install_type=$1
   local version=$2
@@ -25,7 +28,7 @@ install_redis() {
 
     # Make a minor fix that solves problems when newer versions of Lua are
     # installed on the system
-    patch -Np1 -i "${ASDF_PLUGIN_PATH:-$HOME/.asdf/plugins/redis}/lib/adjust-include-paths.patch" || exit 1
+    patch -Np1 -i "${ASDF_PLUGIN_PATH}/lib/adjust-include-paths.patch" || exit 1
 
     if [[ -n "${REDIS_APPLY_PATCHES:-}" ]]; then
       apply_patches "$(fetch_patches "$REDIS_APPLY_PATCHES")"

--- a/lib/adjust-include-paths.patch
+++ b/lib/adjust-include-paths.patch
@@ -1,0 +1,37 @@
+diff --git a/src/Makefile b/src/Makefile
+index 75d18f5e6..0407fdc98 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -116,8 +116,8 @@ endif
+ # Override default settings if possible
+ -include .make-settings
+ 
+-FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS)
+-FINAL_LDFLAGS=$(LDFLAGS) $(REDIS_LDFLAGS) $(DEBUG)
++FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG)
++FINAL_LDFLAGS=$(DEBUG)
+ FINAL_LIBS=-lm
+ DEBUG=-g -ggdb
+ 
+@@ -150,7 +150,10 @@ ifeq ($(uname_S),Darwin)
+ 	# Homebrew's OpenSSL is not linked to /usr/local to avoid
+ 	# conflicts with the system's LibreSSL installation so it
+ 	# must be referenced explicitly during build.
+-ifeq ($(uname_M),arm64)
++	HOMEBREW_PREFIX?=$(shell brew --prefix 2>/dev/null)
++ifdef HOMEBREW_PREFIX
++	OPENSSL_PREFIX?=$(HOMEBREW_PREFIX)/opt/openssl
++else ifeq ($(uname_M),arm64)
+ 	# Homebrew arm64 uses /opt/homebrew as HOMEBREW_PREFIX
+ 	OPENSSL_PREFIX?=/opt/homebrew/opt/openssl
+ else
+@@ -317,6 +320,9 @@ else
+     endef
+ endif
+ 
++FINAL_CFLAGS+=$(CFLAGS) $(REDIS_CFLAGS)
++FINAL_LDFLAGS+=$(LDFLAGS) $(REDIS_LDFLAGS)
++
+ REDIS_CC=$(QUIET_CC)$(CC) $(FINAL_CFLAGS)
+ REDIS_LD=$(QUIET_LINK)$(CC) $(FINAL_LDFLAGS)
+ REDIS_INSTALL=$(QUIET_INSTALL)$(INSTALL)


### PR DESCRIPTION
Some users who happen to have Lua installed system-wide and/or have MacPorts enabled may see compile failures. This commit includes a small patch to the Redis Makefile that adjusts where CFLAGS gets inserted into the compile command to prevent these problems.

This is a redo of #16, which got reverted because `asdf` apparently does not set `$ASDF_PLUGIN_PATH` itself, though it does respect it when searching for plugins.